### PR TITLE
fix nvidia lib paths

### DIFF
--- a/vmware
+++ b/vmware
@@ -176,7 +176,11 @@ determineos() {
     if [ -d "$ULIB/nvidia/current" ]; then
         nvdir="$ULIB/nvidia/current"
     else
-        nvdir=`ls -d $ULIB/nvidia*/xorg|sort -r | head -1`
+        if ls -d $ULIB/nvidia*/xorg > /dev/null 2>&1; then
+            nvdir=`ls -d $ULIB/nvidia*/xorg | sort -r | head -1`
+        else # required on 18.04
+            nvdir=`ls -d $NVIDIA_DEST/nvidia*/xorg |  sort -r | head -1`
+        fi
     fi
     nvdir=`dirname $nvdir`
     NVIDIAVERSION=`basename $nvdir`


### PR DESCRIPTION
Get it working on 18.04 (tested on Mint 19).

Might also require symlinks in /usr/lib/nvidia:
```
/usr/lib/nvidia/libGL.so.1 -> /usr/lib/x86_64-linux-gnu/libGL.so.1
/usr/lib/nvidia/libGL.so.1.0.0 -> /usr/lib/x86_64-linux-gnu/libGL.so.1.0.0
```
And a symlink
`/usr/lib/x86_64-linux-gnu/mesa -> /usr/lib/x86_64-linux-gnu`